### PR TITLE
#70 Linux support for Ubuntu and #72 KP_Enter

### DIFF
--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -24,7 +24,7 @@ class GUI:
 
         # find a font that can draw emojis
         fonts = pygame.sysfont.get_fonts()
-        if (emojis := [font for font in fonts if "emoji" in font 
+        if (emojis := [font for font in fonts if "emoji" in font
                        and font != "notocoloremoji"]):
             self.font = pygame.font.SysFont(emojis[0], 60)
             self.button_font = pygame.font.SysFont(emojis[0], 40)
@@ -174,8 +174,8 @@ class GUI:
                     self.exit_func()
 
                 # Return when enter pressed
-                if (event.type == pygame.KEYDOWN and 
-                    event.key in [pygame.K_RETURN, pygame.K_KP_ENTER]):
+                if (event.type == pygame.KEYDOWN and
+                        event.key in [pygame.K_RETURN, pygame.K_KP_ENTER]):
                     return
 
             # Render the center text

--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -173,7 +173,7 @@ class GUI:
                     self.exit_func()
 
                 # Return when enter pressed
-                if event.type == pygame.KEYDOWN and (event.key == pygame.K_RETURN or event.key == pygame.K_KP_ENTER):
+                if event.type == pygame.KEYDOWN and event.key in [pygame.K_RETURN, pygame.K_KP_ENTER]:
                     return
 
             # Render the center text

--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -24,7 +24,8 @@ class GUI:
 
         # find a font that can draw emojis
         fonts = pygame.sysfont.get_fonts()
-        if emojis := [font for font in fonts if "emoji" in font and font != "notocoloremoji"]:
+        if (emojis := [font for font in fonts if "emoji" in font 
+                       and font != "notocoloremoji"]):
             self.font = pygame.font.SysFont(emojis[0], 60)
             self.button_font = pygame.font.SysFont(emojis[0], 40)
             self.small_font = pygame.font.SysFont(emojis[0], 30)
@@ -173,7 +174,8 @@ class GUI:
                     self.exit_func()
 
                 # Return when enter pressed
-                if event.type == pygame.KEYDOWN and event.key in [pygame.K_RETURN, pygame.K_KP_ENTER]:
+                if (event.type == pygame.KEYDOWN and 
+                    event.key in [pygame.K_RETURN, pygame.K_KP_ENTER]):
                     return
 
             # Render the center text

--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -24,7 +24,7 @@ class GUI:
 
         # find a font that can draw emojis
         fonts = pygame.sysfont.get_fonts()
-        if emojis := [font for font in fonts if "emoji" in font]:
+        if emojis := [font for font in fonts if "emoji" in font and font != "notocoloremoji"]:
             self.font = pygame.font.SysFont(emojis[0], 60)
             self.button_font = pygame.font.SysFont(emojis[0], 40)
             self.small_font = pygame.font.SysFont(emojis[0], 30)

--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -173,7 +173,7 @@ class GUI:
                     self.exit_func()
 
                 # Return when enter pressed
-                if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+                if event.type == pygame.KEYDOWN and (event.key == pygame.K_RETURN or event.key == pygame.K_KP_ENTER):
                     return
 
             # Render the center text

--- a/main.py
+++ b/main.py
@@ -4,8 +4,10 @@ import sys
 
 # Set the taskbar icon to same as pygame window icon
 import ctypes
-myappid = 'KendallDoesCoding.ChooseYourAdventureGame.1.0' # arbitrary string
-ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
+import platform
+if platform.system() == "Windows":
+    myappid = 'KendallDoesCoding.ChooseYourAdventureGame.1.0' # arbitrary string
+    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
 import os
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import sys
 import ctypes
 import platform
 if platform.system() == "Windows":
-    myappid = 'KendallDoesCoding.ChooseYourAdventureGame.1.0' # arbitrary string
+    myappid = 'KendallDoesCoding.ChooseYourAdventureGame.1.0'  # arbitrary string
     ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
 import os

--- a/music_player.py
+++ b/music_player.py
@@ -22,8 +22,7 @@ def fluffingaduck(print_song_name=True):
     sound.play()
 
     if print_song_name:
-        print(Fore.RED + 
-              "Currently Playing - Fluffing a Duck by Kevin Macleod")
+        print(Fore.RED + "Currently Playing - Fluffing a Duck by Kevin Macleod")
 
     return sound
 
@@ -44,7 +43,6 @@ def snakeonthebeach(print_song_name=True):
         print(f"{Fore.RED}Currently Playing - Snake On The Beach by Nico Staf")
 
     return sound
-
 
 def aparisiancafe(print_song_name=True):
     import os

--- a/music_player.py
+++ b/music_player.py
@@ -17,12 +17,12 @@ def fluffingaduck(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/Fluffing-A-Duck.mp3")
+    sound = pygame.mixer.Sound("music/Fluffing-A-Duck.mp3")
     sound.set_volume(0.5)  # Now plays at 50% of full volume.
     sound.play()
 
     if print_song_name:
-        print(Fore.RED +
+        print(Fore.RED + 
               "Currently Playing - Fluffing a Duck by Kevin Macleod")
 
     return sound
@@ -36,7 +36,7 @@ def snakeonthebeach(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/sotb.mp3")
+    sound = pygame.mixer.Sound("music/sotb.mp3")
     sound.set_volume(0.2)  # Now plays at 20% of full volume.
     sound.play()
 
@@ -54,7 +54,7 @@ def aparisiancafe(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/A Parisian Cafe.mp3")
+    sound = pygame.mixer.Sound("music/A Parisian Cafe.mp3")
     sound.play()
 
     if print_song_name:
@@ -71,7 +71,7 @@ def bliss(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/bliss.mp3")
+    sound = pygame.mixer.Sound("music/bliss.mp3")
     sound.set_volume(0.9)  # Now plays at 90% of full volume.
     sound.play()
 
@@ -89,7 +89,7 @@ def happynjoyfulchildren(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/happyandjoyfulchildren.mp3")
+    sound = pygame.mixer.Sound("music/happyandjoyfulchildren.mp3")
     sound.set_volume(0.9)  # Now plays at 90% of full volume.
     sound.play()
 
@@ -107,7 +107,7 @@ def tropicalsoul(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/tropicalsoul.mp3")
+    sound = pygame.mixer.Sound("music/tropicalsoul.mp3")
     sound.set_volume(0.9)  # Now plays at 90% of full volume.
     sound.play()
 
@@ -125,7 +125,7 @@ def newlands(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/newlands.mp3")
+    sound = pygame.mixer.Sound("music/newlands.mp3")
     sound.set_volume(0.5)  # Now plays at 50% of full volume.
     sound.play()
 
@@ -143,7 +143,7 @@ def beachvibes(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/beachvibes.mp3")
+    sound = pygame.mixer.Sound("music/beachvibes.mp3")
     sound.set_volume(0.5)  # Now plays at 50% of full volume.
     sound.play()
 
@@ -151,6 +151,7 @@ def beachvibes(print_song_name=True):
         print(f"{Fore.RED}Currently Playing - Beach Vibes by Luke Bergs")
 
     return sound
+
 
 def tropicalfever(print_song_name=True):
     import os
@@ -160,7 +161,7 @@ def tropicalfever(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/tropicalfever.mp3")
+    sound = pygame.mixer.Sound("music/tropicalfever.mp3")
     sound.set_volume(0.2)  # Now plays at 20% of full volume.
     sound.play()
 
@@ -168,6 +169,7 @@ def tropicalfever(print_song_name=True):
         print(f"{Fore.RED}Currently Playing - Tropical Fever by Luke Bergs & LiQWYD")
 
     return 
+
 
 def happyadricanvillage(print_song_name=True):
     import os
@@ -177,7 +179,7 @@ def happyadricanvillage(print_song_name=True):
 
     pygame.init()
     pygame.mixer.init()
-    sound = pygame.mixer.Sound("Music/happyafricanvillage.mp3")
+    sound = pygame.mixer.Sound("music/happyafricanvillage.mp3")
     sound.set_volume(0.2)  # Now plays at 20% of full volume.
     sound.play()
 
@@ -185,7 +187,6 @@ def happyadricanvillage(print_song_name=True):
         print(f"{Fore.RED}Currently Playing - Happy African Village by John Bartmann")
 
     return sound
-
 
 
 songs = [
@@ -208,7 +209,7 @@ def music():
     pygame.init()
     pygame.mixer.init()
 
-    start_song(print_song_name = not GUIInstance.run_gui)
+    start_song(print_song_name=not GUIInstance.run_gui)
     if not GUIInstance.run_gui:
         print(f"{Fore.BLUE}Music has started")
 

--- a/music_player.py
+++ b/music_player.py
@@ -22,7 +22,8 @@ def fluffingaduck(print_song_name=True):
     sound.play()
 
     if print_song_name:
-        print(Fore.RED + "Currently Playing - Fluffing a Duck by Kevin Macleod")
+        print(Fore.RED +
+              "Currently Playing - Fluffing a Duck by Kevin Macleod")
 
     return sound
 
@@ -43,6 +44,7 @@ def snakeonthebeach(print_song_name=True):
         print(f"{Fore.RED}Currently Playing - Snake On The Beach by Nico Staf")
 
     return sound
+
 
 def aparisiancafe(print_song_name=True):
     import os
@@ -150,7 +152,6 @@ def beachvibes(print_song_name=True):
 
     return sound
 
-
 def tropicalfever(print_song_name=True):
     import os
 
@@ -168,7 +169,6 @@ def tropicalfever(print_song_name=True):
 
     return 
 
-
 def happyadricanvillage(print_song_name=True):
     import os
 
@@ -185,6 +185,7 @@ def happyadricanvillage(print_song_name=True):
         print(f"{Fore.RED}Currently Playing - Happy African Village by John Bartmann")
 
     return sound
+
 
 
 songs = [
@@ -207,7 +208,7 @@ def music():
     pygame.init()
     pygame.mixer.init()
 
-    start_song(print_song_name=not GUIInstance.run_gui)
+    start_song(print_song_name = not GUIInstance.run_gui)
     if not GUIInstance.run_gui:
         print(f"{Fore.BLUE}Music has started")
 


### PR DESCRIPTION
#70 [FEATURE REQUEST] Linux support
- Change the path of the music folder in  music_player.py, which is not the same as in the file system
- If Statement for Windows Part of setting SetCurrentProcessExplicitAppUserModelID
-  Ignoring notocoloremoji
#72 Support for K_KP_ENTER:
- add the key

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Proposed Changes
- change path to music instead of Music
-  included platform and check the OS and SetCurrentProcessExplicitAppUserModelID only on Windows
- fix problem with notocoloremoji font on ubuntu
-  proposal to handle the KP_Enter key as return

# Additional Info
- it would be better to use the correct path, even if it works on windows

## Checklist:

- [x] My code follows the style guidelines of this project and have read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings